### PR TITLE
Expand checkbox array in MultiFileSelect

### DIFF
--- a/Edit Scripts/lib/mteFunctions.pas
+++ b/Edit Scripts/lib/mteFunctions.pas
@@ -1,6 +1,6 @@
 {
   matortheeternal's Functions
-  edited 11/12/2015
+  edited 14/05/2023
   
   A set of useful functions for use in TES5Edit scripts.
   
@@ -2242,7 +2242,7 @@ var
   frm: TForm;
   pnl: TPanel;
   lastTop, contentHeight: Integer;
-  cbArray: Array[0..255] of TCheckBox;
+  cbArray: Array[0..9999] of TCheckBox;
   lbl: TLabel;
   sb: TScrollBox;
   i: Integer;


### PR DESCRIPTION
If user has more then 255 active plugins, MultiFileSelect fails to create checkboxes for all of them, so let's rise the max count to 10K. Unfortunately we cannot do
```
cbArray: Array of TCheckBox;
...
SetLength(cbArray, FileCount);
```