### PR TITLE
Further MultiFileSelect expansion

### DIFF
--- a/Edit Scripts/lib/mteFunctions.pas
+++ b/Edit Scripts/lib/mteFunctions.pas
@@ -1,6 +1,6 @@
 {
   matortheeternal's Functions
-  edited 14/05/2023
+  edited 15/05/2023
   
   A set of useful functions for use in TES5Edit scripts.
   
@@ -2332,8 +2332,8 @@ begin
         f := FileByLoadOrder(i);
         p := Trunc(i / 500);
         e := i - p * 500;
-        if (cbArray[p,e].Checked) and (sl.IndexOf(GetFileName(f)) = -1) then
-          sl.Add(GetFileName(f));
+        if (cbArray[p,e].Checked) and (sl.IndexOf(GetFileName(f)) = -1)
+        then sl.Add(GetFileName(f));
       end;
     end;
     


### PR DESCRIPTION
Change one scrollbox to scrollbox [20] array. Change checkboxes form [10K] single-dimensional array to [20][500] two-dimensional array. If user have more then 500 plugins > make them go to the next scrollbox.

We cannot show all scrollboxes in the same time so make 2 buttons (prev and next page). Only one page is visible but other exist with their checked entries and they even save their scroll position.

Some new integer variables explanation:
- mi > Max item index, previous (FileCount - 2).
- p > Current page of scrollbox array.
- mp > Max page index.
- e > Entry of checkbox inside of scrollbox.
- me > Max entry index of checkbox.
- wid > Make hex indexes of items in list to use calculated width instead of static. For example: 10 plugins - width is 1 (0-F), 100 plugins - width is 2 (00-FF), 1000 plugins - width is 3 (000-FFF).